### PR TITLE
feat: don't require the user to `use std::ops`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.direnv

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Provides a macro to simplify operator overloading. See the [documentation](https
 ```rust
 extern crate overload;
 use overload::overload;
-use std::ops; // <- don't forget this or you'll get nasty errors
 
 #[derive(PartialEq, Debug)]
 struct Val {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1725099143,
+        "narHash": "sha256-CHgumPZaC7z+WYx72WgaLt2XF0yUVzJS60rO4GZ7ytY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5629520edecb69630a3f4d17d3d33fc96c13f6fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "utils": "utils"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1725157860,
+        "narHash": "sha256-DhqyM7XJYKj+WAEaYwMtXaYX66tA+lOd31sd5QkxLDM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "1fd72e343c6890f695243a37b367a1e3b90a49ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, utils }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay )];
+        pkgs = import nixpkgs { inherit system overlays; };
+      in
+      {
+        devShell = with pkgs; mkShell {
+         #nativeBuildInputs = [
+            #pkg-config
+          #];
+          buildInputs = [ 
+            (rust-bin.stable.latest.default.override {
+              targets = [
+                "x86_64-unknown-linux-musl"
+              ];
+            })
+            rust-analyzer # LSP
+            cargo-nextest # much faster test runner
+          ];
+          RUST_SRC_PATH = rustPlatform.rustLibSrc;
+        };
+      });
+}

--- a/src/assignment.rs
+++ b/src/assignment.rs
@@ -16,12 +16,12 @@ macro_rules! _overload_assignment {
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! _overload_assignment_internal {
-    ($op_trait:ident, $op_fn:ident, $li:ident, $lt:ty, $ri:ident, $rt:ty, $body:block) => (        
-        impl ops::$op_trait<$rt> for $lt {
+    ($op_trait:ident, $op_fn:ident, $li:ident, $lt:ty, $ri:ident, $rt:ty, $body:block) => {
+        impl std::ops::$op_trait<$rt> for $lt {
             fn $op_fn(&mut self, $ri: $rt) {
                 let $li = self;
                 $body
             }
         }
-    );
+    };
 }

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -16,13 +16,13 @@ macro_rules! _overload_binary {
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! _overload_binary_internal {
-    ($op_trait:ident, $op_fn:ident, $li:ident, $lt:ty, $ri:ident, $rt:ty, $out:ty, $body:block) => (
-        impl ops::$op_trait<$rt> for $lt {
+    ($op_trait:ident, $op_fn:ident, $li:ident, $lt:ty, $ri:ident, $rt:ty, $out:ty, $body:block) => {
+        impl std::ops::$op_trait<$rt> for $lt {
             type Output = $out;
             fn $op_fn(self, $ri: $rt) -> Self::Output {
                 let $li = self;
                 $body
             }
         }
-    );
+    };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,15 @@
 //! Provides a macro to simplify operator overloading.
-//! 
+//!
 //! To use, include the following:
 //! ```
 //! extern crate overload;
 //! use overload::overload;
-//! use std::ops; // <- don't forget this or you'll get nasty errors
 //! ```
-//! 
+//!
 //! # Introduction
-//! 
+//!
 //! Suppose we have the following `struct` definition:
-//! ``` 
+//! ```
 //! #[derive(PartialEq, Debug)]
 //! struct Val {
 //!     v: i32
@@ -20,7 +19,6 @@
 //! ```
 //! # extern crate overload;
 //! # use overload::overload;
-//! # use std::ops;
 //! # #[derive(PartialEq, Debug)]
 //! # struct Val {
 //! #   v: i32
@@ -41,7 +39,6 @@
 //! ```
 //! # extern crate overload;
 //! # use overload::overload;
-//! # use std::ops;
 //! # #[derive(PartialEq, Debug)]
 //! # struct Val {
 //! #   v: i32
@@ -49,14 +46,13 @@
 //! # overload!((a: Val) + (b: Val) -> Val { Val { v: a.v + b.v } });
 //! assert_eq!(Val{v:3} + Val{v:5}, Val{v:8});
 //! ```
-//! 
+//!
 //! # Owned and borrowed types
-//! 
+//!
 //! If we also wanted to overload addition for the borrowed type `&Val` we could write:
 //! ```
 //! # extern crate overload;
 //! # use overload::overload;
-//! # use std::ops;
 //! # #[derive(PartialEq, Debug)]
 //! # struct Val {
 //! #   v: i32
@@ -67,7 +63,6 @@
 //! ```
 //! # extern crate overload;
 //! # use overload::overload;
-//! # use std::ops;
 //! # #[derive(PartialEq, Debug)]
 //! # struct Val {
 //! #   v: i32
@@ -76,14 +71,13 @@
 //! overload!((a: &Val) + (b: Val) -> Val { Val { v: a.v + b.v } });
 //! ```
 //! Let's see how we can write these combinations more concisely.
-//! 
+//!
 //! We can include a `?` in front of a type to indicate that it should stand in for both the owned and borrowed type.
-//! 
+//!
 //! To overload addition for all four combinations between `Val` and `&Val` we can therefore simply include a `?` in front of both types:
 //! ```
 //! # extern crate overload;
 //! # use overload::overload;
-//! # use std::ops;
 //! # #[derive(PartialEq, Debug)]
 //! # struct Val {
 //! #   v: i32
@@ -99,7 +93,7 @@
 //!         Val { v: a.v + b.v }
 //!     }
 //! }
-//! 
+//!
 //! impl ops::Add<&Val> for Val {
 //!     type Output = Val;
 //!     fn add(self, b: &Val) -> Self::Output {
@@ -107,7 +101,7 @@
 //!         Val { v: a.v + b.v }
 //!     }
 //! }
-//! 
+//!
 //! impl ops::Add<Val> for &Val {
 //!     type Output = Val;
 //!     fn add(self, b: Val) -> Self::Output {
@@ -115,7 +109,7 @@
 //!         Val { v: a.v + b.v }
 //!     }
 //! }
-//! 
+//!
 //! impl ops::Add<&Val> for &Val {
 //!     type Output = Val;
 //!     fn add(self, b: &Val) -> Self::Output {
@@ -123,12 +117,11 @@
 //!         Val { v: a.v + b.v }
 //!     }
 //! }
-//! ``` 
+//! ```
 //! We are now able to add `Val`s and `&Val`s in any combination:
 //! ```
 //! # extern crate overload;
 //! # use overload::overload;
-//! # use std::ops;
 //! # #[derive(PartialEq, Debug)]
 //! # struct Val {
 //! #   v: i32
@@ -141,15 +134,15 @@
 //! ```
 //!
 //! # Binary operators
-//! 
+//!
 //! The general syntax to overload a binary operator between types `<a_type>` and `<b_type>` is:
 //! ```ignore
 //! overload!((<a_ident>: <a_type>) <op> (<b_ident>: <b_type>) -> <out_type> { /*body*/ });
 //! ```
 //! Inside the body you can use `<a_ident>` and `<b_ident>` freely to perform any computation.
-//! 
+//!
 //! The last line of the body needs to be an expression (i.e. no `;` at the end of the line) of type `<out_type>`.
-//! 
+//!
 //! | Operator | Example                                                         | Trait  |
 //! |----------|-----------------------------------------------------------------|--------|
 //! | +        | `overload!((a: A) + (b: B) -> C { /*...*/ });`                   | Add    |           
@@ -162,15 +155,15 @@
 //! | ^        | `overload!((a: A) ^ (b: B) -> C { /*...*/ });`                   | BitXor |
 //! | <<       | `overload!((a: A) << (b: B) -> C { /*...*/ });`                  | Shl    |
 //! | >>       | `overload!((a: A) >> (b: B) -> C { /*...*/ });`                  | Shr    |
-//! 
+//!
 //! # Assignment operators
-//! 
+//!
 //! The general syntax to overload an assignment operator between types `<a_type>` and `<b_type>` is:
 //! ```ignore
 //! overload!((<a_ident>: &mut <a_type>) <op> (<b_ident>: <b_type>) { /*body*/ });
 //! ```
 //! Inside the body you can use `<a_ident>` and `<b_ident>` freely to perform any computation and mutate `<a_ident>` as desired.
-//! 
+//!
 //! | Operator | Example                                                          | Trait        |
 //! |----------|------------------------------------------------------------------|--------------|
 //! | +=       | `overload!((a: &mut A) += (b: B) { /*...*/ });`                   | AddAssign    |           
@@ -183,24 +176,24 @@
 //! | ^=       | `overload!((a: &mut A) ^= (b: B) { /*...*/ });`                   | BitXorAssign |
 //! | <<=      | `overload!((a: &mut A) <<= (b: B) { /*...*/ });`                  | ShlAssign    |
 //! | >>=      | `overload!((a: &mut A) >>= (b: B) { /*...*/ });`                  | ShrAssign    |
-//! 
+//!
 //! # Unary operators
-//! 
+//!
 //! The general syntax to overload a unary operator for type `<a_type>` is:
 //! ```ignore
 //! overload!(<op> (<a_ident>: <a_type>) -> <out_type> { /*body*/ });
 //! ```
 //! Inside the body you can use `<a_ident>` freely to perform any computation.
-//! 
+//!
 //! The last line of the body needs to be an expression (i.e. no `;` at the end of the line) of type `<out_type>`.
-//! 
+//!
 //! | Operator | Example                                                 | Trait |
 //! |----------|---------------------------------------------------------|-------|
 //! | -        | `overload!(- (a: A) -> B { /*...*/ });`                  | Neg   |
 //! | !        | `overload!(! (a: A) -> B { /*...*/ });`                  | Not   |  
-//! 
+//!
 //! # Notes
-//! 
+//!
 //! Remember that you can only overload operators between one or more types if at least one of the types is defined in the current crate.
 
 #[macro_use]
@@ -216,42 +209,42 @@ mod binary;
 #[macro_export(local_inner_macros)]
 macro_rules! overload {
     // Unary (both owned and borrowed)
-    ($op:tt ($i:ident : ? $t:ty) -> $out:ty $body:block) => (
+    ($op:tt ($i:ident : ? $t:ty) -> $out:ty $body:block) => {
         _overload_unary!($op, $i, $t, $out, $body);
         _overload_unary!($op, $i, &$t, $out, $body);
-    );
+    };
     // Unary (either owned or borrowed)
-    ($op:tt ($i:ident : $t:ty) -> $out:ty $body:block) => (
+    ($op:tt ($i:ident : $t:ty) -> $out:ty $body:block) => {
         _overload_unary!($op, $i, $t, $out, $body);
-    );
+    };
     // Assignment (both owned and borrowed)
-    (($li:ident : &mut $lt:ty) $op:tt ($ri:ident : ? $rt:ty) $body:block) => (
+    (($li:ident : &mut $lt:ty) $op:tt ($ri:ident : ? $rt:ty) $body:block) => {
         _overload_assignment!($op, $li, $lt, $ri, $rt, $body);
         _overload_assignment!($op, $li, $lt, $ri, &$rt, $body);
-    );
+    };
     // Assignment (either owned or borrowed)
-    (($li:ident : &mut $lt:ty) $op:tt ($ri:ident : $rt:ty) $body:block) => (
+    (($li:ident : &mut $lt:ty) $op:tt ($ri:ident : $rt:ty) $body:block) => {
         _overload_assignment!($op, $li, $lt, $ri, $rt, $body);
-    );    
+    };
     // Binary (both - both)
-    (($li:ident : ? $lt:ty) $op:tt ($ri:ident : ? $rt:ty) -> $out:ty $body:block) => (
+    (($li:ident : ? $lt:ty) $op:tt ($ri:ident : ? $rt:ty) -> $out:ty $body:block) => {
         _overload_binary!($op, $li, $lt, $ri, $rt, $out, $body);
         _overload_binary!($op, $li, $lt, $ri, &$rt, $out, $body);
         _overload_binary!($op, $li, &$lt, $ri, $rt, $out, $body);
         _overload_binary!($op, $li, &$lt, $ri, &$rt, $out, $body);
-    );
+    };
     // Binary (both - either)
-    (($li:ident : ? $lt:ty) $op:tt ($ri:ident : $rt:ty) -> $out:ty $body:block) => (
+    (($li:ident : ? $lt:ty) $op:tt ($ri:ident : $rt:ty) -> $out:ty $body:block) => {
         _overload_binary!($op, $li, $lt, $ri, $rt, $out, $body);
         _overload_binary!($op, $li, &$lt, $ri, $rt, $out, $body);
-    );
+    };
     // Binary (either - both)
-    (($li:ident : $lt:ty) $op:tt ($ri:ident : ? $rt:ty) -> $out:ty $body:block) => (
+    (($li:ident : $lt:ty) $op:tt ($ri:ident : ? $rt:ty) -> $out:ty $body:block) => {
         _overload_binary!($op, $li, $lt, $ri, $rt, $out, $body);
         _overload_binary!($op, $li, $lt, $ri, &$rt, $out, $body);
-    );
+    };
     // Binary (either - either)
-    (($li:ident : $lt:ty) $op:tt ($ri:ident : $rt:ty) -> $out:ty $body:block) => (
+    (($li:ident : $lt:ty) $op:tt ($ri:ident : $rt:ty) -> $out:ty $body:block) => {
         _overload_binary!($op, $li, $lt, $ri, $rt, $out, $body);
-    );
+    };
 }

--- a/src/unary.rs
+++ b/src/unary.rs
@@ -8,13 +8,13 @@ macro_rules! _overload_unary {
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! _overload_unary_internal {
-    ($op_trait:ident, $op_fn:ident, $i:ident, $t:ty, $out:ty, $body:block) => (        
-        impl ops::$op_trait for $t {
+    ($op_trait:ident, $op_fn:ident, $i:ident, $t:ty, $out:ty, $body:block) => {
+        impl std::ops::$op_trait for $t {
             type Output = $out;
             fn $op_fn(self) -> Self::Output {
                 let $i = self;
                 $body
             }
         }
-    );
+    };
 }

--- a/tests/assignment.rs
+++ b/tests/assignment.rs
@@ -1,6 +1,5 @@
 extern crate overload;
 use overload::overload;
-use std::ops;
 
 #[derive(PartialEq, Debug)]
 struct A(i32);

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -1,6 +1,5 @@
 extern crate overload;
 use overload::overload;
-use std::ops;
 
 #[derive(PartialEq, Debug)]
 struct A(i32);

--- a/tests/unary.rs
+++ b/tests/unary.rs
@@ -1,6 +1,5 @@
 extern crate overload;
 use overload::overload;
-use std::ops;
 
 #[derive(PartialEq, Debug)]
 struct A(i32);


### PR DESCRIPTION
Hi! I really like your project. It scratches a particular itch I had and the syntax of the macro looks clean and intuitive. I think there may be a few ways in which we could improve it. For this first PR, I took the lowest hanging fruit by fully qualifying the use of `std::ops` in the macros, thus not requiring the consumers of the library to import it themselves.

If you're okay with it, I may have a couple more PR's to do for some other issues or extensions.

BTW, I've also added a `flake.nix` and `.envrc` files to ease development in my machine. By using the nix package manager, one can bootstrap a suitable development environment for this project just by entering the directory. Are you okay with adding it to the master branch? I think it could also make it easier for other contributors to start working on the project. If not, we could just cherry pick the `std::ops`-related changes.

Thank you!